### PR TITLE
Implement simple support ticket system

### DIFF
--- a/vpn_bot/bot/handlers/common/main_menu.py
+++ b/vpn_bot/bot/handlers/common/main_menu.py
@@ -5,6 +5,8 @@ from aiogram.types import Message
 from vpn_bot.utils.i18n import get_user_lang
 from vpn_bot.utils.i18n import t
 from vpn_bot.utils.i18n import match_key_by_text
+from aiogram.fsm.context import FSMContext
+from vpn_bot.bot.states import SupportStates
 
 router = Router()
 print("📦 main_menu.py router loaded ✅")
@@ -51,6 +53,6 @@ async def handle_guide(message: Message):
 
 
 @router.message(lambda msg: match_key_by_text("support", msg.text))
-async def handle_support(message: Message):
-    lang = await get_user_lang(message.from_user.id)
-    await message.answer(t("send_ticket_msg", lang))
+async def handle_support(message: Message, state: FSMContext):
+    await message.answer("لطفاً موضوع تیکت را وارد کنید:")
+    await state.set_state(SupportStates.waiting_for_subject)

--- a/vpn_bot/bot/handlers/common/start.py
+++ b/vpn_bot/bot/handlers/common/start.py
@@ -9,6 +9,7 @@ from vpn_bot.utils.i18n import t
 from vpn_bot.services.user_service import upsert_user
 from vpn_bot.keyboards.language import language_keyboard
 from vpn_bot.keyboards.main import main_menu_inline
+from vpn_bot.support_settings import ADMIN_USER_ID, set_admin
 from vpn_bot.context.lang_context import current_lang
 
 router = Router()
@@ -19,6 +20,11 @@ async def handle_start(message: Message):
     user_id = message.from_user.id
     username = message.from_user.username
     await upsert_user(user_id=user_id, username=username)
+
+    if ADMIN_USER_ID is None:
+        set_admin(user_id)
+        await message.answer("شما به عنوان ادمین ثبت شدید.")
+        return
 
     # استفاده از زبان تلگرام برای اولین بار
     lang = message.from_user.language_code or "en"

--- a/vpn_bot/bot/handlers/support/ticket_support.py
+++ b/vpn_bot/bot/handlers/support/ticket_support.py
@@ -1,0 +1,72 @@
+from aiogram import Router, F
+from aiogram.types import Message
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.types import ReplyKeyboardRemove
+
+from vpn_bot.bot.states import SupportStates
+from vpn_bot.services.support_service import (
+    save_ticket,
+    assign_ticket,
+    get_active_ticket_for_operator,
+    get_user_for_ticket,
+)
+from vpn_bot.bot_instance import bot
+from vpn_bot.support_settings import get_next_operator, OPERATORS
+import logging
+
+router = Router()
+logger = logging.getLogger(__name__)
+
+@router.message(Command("support"))
+async def support_start(message: Message, state: FSMContext):
+    await message.answer("لطفاً موضوع تیکت را وارد کنید:", reply_markup=ReplyKeyboardRemove())
+    await state.set_state(SupportStates.waiting_for_subject)
+
+
+@router.message(SupportStates.waiting_for_subject)
+async def get_subject(message: Message, state: FSMContext):
+    await state.update_data(subject=message.text)
+    await message.answer("لطفاً توضیحات خود را وارد کنید:")
+    await state.set_state(SupportStates.waiting_for_description)
+
+
+@router.message(SupportStates.waiting_for_description)
+async def get_description(message: Message, state: FSMContext):
+    data = await state.get_data()
+    subject = data.get("subject", "")
+    description = message.text
+    user_id = message.from_user.id
+
+    ticket_id = await save_ticket(user_id=user_id, subject=subject, description=description)
+
+    operator_id = get_next_operator()
+    if operator_id is not None:
+        await assign_ticket(ticket_id, operator_id)
+        try:
+            await bot.send_message(
+                operator_id,
+                f"تیکت جدید #{ticket_id}\nموضوع: {subject}\n{description}\nکاربر: {user_id}"
+            )
+        except Exception as e:
+            logger.error("خطا در ارسال پیام به اپراتور %s: %s", operator_id, e)
+    else:
+        logger.error("هیچ اپراتوری تعریف نشده است")
+
+    await message.answer(f"تیکت شما ثبت شد. شناسه: {ticket_id}")
+    await state.clear()
+
+
+@router.message(lambda m: m.from_user.id in OPERATORS)
+async def operator_reply(message: Message):
+    operator_id = message.from_user.id
+    ticket_id = await get_active_ticket_for_operator(operator_id)
+    if not ticket_id:
+        return
+    user_id = await get_user_for_ticket(ticket_id)
+    if not user_id:
+        return
+    try:
+        await bot.send_message(user_id, message.text)
+    except Exception as e:
+        logger.error("خطا در ارسال پیام اپراتور %s به کاربر %s: %s", operator_id, user_id, e)

--- a/vpn_bot/bot/states.py
+++ b/vpn_bot/bot/states.py
@@ -10,8 +10,8 @@ class TrialStates(StatesGroup):
 
 
 class SupportStates(StatesGroup):
-    """States for the basic live chat support."""
+    """States for user support ticket creation and live chat."""
 
-    ask_topic = State()
-    receive_description = State()
+    waiting_for_subject = State()
+    waiting_for_description = State()
     live_chat = State()

--- a/vpn_bot/services/support_service.py
+++ b/vpn_bot/services/support_service.py
@@ -1,0 +1,53 @@
+from sqlalchemy import select
+from vpn_bot.db.core.session import AsyncSessionLocal
+from vpn_bot.db.models.support_ticket import SupportTicket
+from vpn_bot.db.models.support_message import SupportMessage
+from vpn_bot.db.models.support_agent import SupportAgent
+
+async def save_ticket(user_id: int, subject: str, description: str) -> int:
+    async with AsyncSessionLocal() as session:
+        ticket = SupportTicket(user_id=user_id, question=subject, status="open")
+        session.add(ticket)
+        await session.flush()
+        msg = SupportMessage(
+            ticket_id=ticket.id,
+            from_user="user",
+            content=description
+        )
+        session.add(msg)
+        await session.commit()
+        return ticket.id
+
+async def assign_ticket(ticket_id: int, operator_id: int):
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(select(SupportAgent).where(SupportAgent.user_id == operator_id))
+        agent = result.scalar_one_or_none()
+        if not agent:
+            agent = SupportAgent(user_id=operator_id)
+            session.add(agent)
+            await session.flush()
+        ticket = await session.get(SupportTicket, ticket_id)
+        if ticket:
+            ticket.agent_id = agent.id
+        await session.commit()
+
+async def get_active_ticket_for_operator(operator_id: int) -> int | None:
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(select(SupportAgent).where(SupportAgent.user_id == operator_id))
+        agent = result.scalar_one_or_none()
+        if not agent:
+            return None
+        result = await session.execute(
+            select(SupportTicket.id)
+            .where(SupportTicket.agent_id == agent.id)
+            .where(SupportTicket.status == "open")
+            .order_by(SupportTicket.created_at)
+            .limit(1)
+        )
+        row = result.first()
+        return row[0] if row else None
+
+async def get_user_for_ticket(ticket_id: int) -> int | None:
+    async with AsyncSessionLocal() as session:
+        ticket = await session.get(SupportTicket, ticket_id)
+        return ticket.user_id if ticket else None

--- a/vpn_bot/support_settings.py
+++ b/vpn_bot/support_settings.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+DATA_FILE = Path(__file__).with_name("support_data.json")
+
+try:
+    data = json.loads(DATA_FILE.read_text())
+except Exception:
+    data = {"admin_id": None, "operator_index": 0, "operators": []}
+
+ADMIN_USER_ID = data.get("admin_id")
+OPERATORS = data.get("operators", [])
+operator_index = data.get("operator_index", 0)
+
+def _save():
+    DATA_FILE.write_text(json.dumps({
+        "admin_id": ADMIN_USER_ID,
+        "operator_index": operator_index,
+        "operators": OPERATORS
+    }))
+
+def set_admin(user_id: int) -> None:
+    global ADMIN_USER_ID
+    ADMIN_USER_ID = user_id
+    _save()
+
+def get_next_operator() -> int | None:
+    global operator_index
+    if not OPERATORS:
+        return None
+    op = OPERATORS[operator_index % len(OPERATORS)]
+    operator_index = (operator_index + 1) % len(OPERATORS)
+    _save()
+    return op


### PR DESCRIPTION
## Summary
- register admin on first `/start`
- add ticket FSM flow and operator chat
- create persistent support settings
- add DB helpers for support tickets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vpn_bot')*

------
https://chatgpt.com/codex/tasks/task_e_68434eafdc088321b8ec839e6b75fa1b