### PR TITLE
Implement support phase1

### DIFF
--- a/config.py
+++ b/config.py
@@ -21,7 +21,12 @@ def getenv(key: str, default=None, required=False, cast_type=str):
 # 🤖 Telegram Bot Settings
 # ========================
 BOT_TOKEN = getenv("BOT_TOKEN", required=True)
-ADMIN_IDS = [int(x) for x in os.getenv("ADMINS", "").split(",") if x.strip().isdigit()]
+# از python-dotenv برای بارگذاری ADMIN_IDS استفاده می‌کنیم
+ADMIN_IDS = [
+    int(x)
+    for x in os.getenv("ADMIN_IDS", "").split(",")
+    if x.strip().isdigit()
+]
 ADMIN_CHAT_ID = int(os.getenv("ADMIN_CHAT_ID", 0))
 
 # ====================

--- a/scripts/tests/test_start.py
+++ b/scripts/tests/test_start.py
@@ -10,9 +10,9 @@ async def test_start_for_admin(monkeypatch):
     message = AsyncMock(spec=Message)
     message.from_user = User(id=42, is_bot=False, first_name="Admin")
 
-    await start_module.cmd_start(message)
+    await start_module.start_command(message, AsyncMock())
 
-    message.reply.assert_called_once_with("بات آماده به‌کار است.")
+    message.answer.assert_called_once_with("بات آماده به‌کار است.")
 
 
 @pytest.mark.asyncio
@@ -21,6 +21,6 @@ async def test_start_for_non_admin(monkeypatch):
     message = AsyncMock(spec=Message)
     message.from_user = User(id=7, is_bot=False, first_name="User")
 
-    await start_module.cmd_start(message)
+    await start_module.start_command(message, AsyncMock())
 
-    message.reply.assert_called_once_with("شما دسترسی ادمین ندارید.")
+    message.answer.assert_called_once_with("شما دسترسی ادمین ندارید.")

--- a/scripts/tests/test_support.py
+++ b/scripts/tests/test_support.py
@@ -1,0 +1,41 @@
+import pytest
+from unittest.mock import AsyncMock
+from aiogram.types import Message, User
+from aiogram.fsm.context import FSMContext
+
+from vpn_bot.bot.handlers.support import support as support_module
+
+
+@pytest.mark.asyncio
+async def test_forward_initial_message(monkeypatch):
+    state = AsyncMock(spec=FSMContext)
+    state.get_data = AsyncMock(return_value={"topic": "test"})
+    state.update_data = AsyncMock()
+    state.set_state = AsyncMock()
+
+    message = AsyncMock(spec=Message)
+    message.text = "description"
+    message.from_user = User(id=123, is_bot=False, first_name="u")
+
+    send_mock = AsyncMock()
+    monkeypatch.setattr(support_module, "bot", AsyncMock(send_message=send_mock))
+    monkeypatch.setattr(support_module, "ADMIN_IDS", [99])
+
+    await support_module.support_receive_description(message, state)
+
+    send_mock.assert_awaited()
+    assert "test" in send_mock.call_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_admin_reply(monkeypatch):
+    message = AsyncMock(spec=Message)
+    message.text = "123#ok"
+    message.from_user = User(id=99, is_bot=False, first_name="admin")
+    message.bot = AsyncMock()
+
+    monkeypatch.setattr(support_module, "ADMIN_IDS", [99])
+
+    await support_module.admin_live_chat_handler(message)
+
+    message.bot.send_message.assert_awaited_with(123, "[پاسخ ادمین]: ok")

--- a/vpn_bot/bot/handlers/common/main_menu.py
+++ b/vpn_bot/bot/handlers/common/main_menu.py
@@ -55,4 +55,4 @@ async def handle_guide(message: Message):
 @router.message(lambda msg: match_key_by_text("support", msg.text))
 async def handle_support(message: Message, state: FSMContext):
     await message.answer("لطفاً موضوع تیکت را وارد کنید:")
-    await state.set_state(SupportStates.waiting_for_subject)
+    await state.set_state(SupportStates.ask_topic)

--- a/vpn_bot/bot/handlers/common/start.py
+++ b/vpn_bot/bot/handlers/common/start.py
@@ -1,13 +1,21 @@
-import os
-from aiogram import types
-from vpn_bot.bot_instance import dp
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+from aiogram.fsm.context import FSMContext
 
-ADMIN_IDS = [int(x) for x in os.getenv("ADMIN_IDS", "").split(",") if x]
+from config import ADMIN_IDS
 
-@dp.message_handler(commands=["start"])
-async def cmd_start(message: types.Message):
+router = Router()
+
+
+@router.message(Command("start"))
+async def start_command(message: Message, state: FSMContext) -> None:
+    """Simple /start handler using Aiogram v3."""
     user_id = message.from_user.id
     if user_id in ADMIN_IDS:
-        await message.reply("بات آماده به‌کار است.")
+        await message.answer("بات آماده به‌کار است.")
     else:
-        await message.reply("شما دسترسی ادمین ندارید.")
+        await message.answer("شما دسترسی ادمین ندارید.")
+
+# سازگاری با نسخه‌های قدیمی‌تر
+cmd_start = start_command

--- a/vpn_bot/bot/handlers/support/ticket_support.py
+++ b/vpn_bot/bot/handlers/support/ticket_support.py
@@ -21,17 +21,17 @@ logger = logging.getLogger(__name__)
 @router.message(Command("support"))
 async def support_start(message: Message, state: FSMContext):
     await message.answer("لطفاً موضوع تیکت را وارد کنید:", reply_markup=ReplyKeyboardRemove())
-    await state.set_state(SupportStates.waiting_for_subject)
+    await state.set_state(SupportStates.ask_topic)
 
 
-@router.message(SupportStates.waiting_for_subject)
+@router.message(SupportStates.ask_topic)
 async def get_subject(message: Message, state: FSMContext):
     await state.update_data(subject=message.text)
     await message.answer("لطفاً توضیحات خود را وارد کنید:")
-    await state.set_state(SupportStates.waiting_for_description)
+    await state.set_state(SupportStates.receive_description)
 
 
-@router.message(SupportStates.waiting_for_description)
+@router.message(SupportStates.receive_description)
 async def get_description(message: Message, state: FSMContext):
     data = await state.get_data()
     subject = data.get("subject", "")

--- a/vpn_bot/bot/states.py
+++ b/vpn_bot/bot/states.py
@@ -12,6 +12,8 @@ class TrialStates(StatesGroup):
 class SupportStates(StatesGroup):
     """States for user support ticket creation and live chat."""
 
-    waiting_for_subject = State()
-    waiting_for_description = State()
+    # فاز نخست پشتیبانی: دریافت موضوع و توضیح مشکل
+    ask_topic = State()
+    receive_description = State()
+    # پس از ثبت، کاربر وارد چت زنده می‌شود
     live_chat = State()


### PR DESCRIPTION
## Summary
- read `ADMIN_IDS` via `python-dotenv`
- update `/start` handler for aiogram v3
- refine support states and handlers
- broadcast support messages to all admins
- unit tests for start and basic support flow

## Testing
- `pytest -v` *(fails: ModuleNotFoundError for 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_68445cb7ba348321ad3bc5ff2f7f3b94