### PR TITLE
Implement basic support FSM

### DIFF
--- a/vpn_bot/bot/handlers/common/main_menu.py
+++ b/vpn_bot/bot/handlers/common/main_menu.py
@@ -55,4 +55,4 @@ async def handle_guide(message: Message):
 @router.message(lambda msg: match_key_by_text("support", msg.text))
 async def handle_support(message: Message, state: FSMContext):
     await message.answer("لطفاً موضوع تیکت را وارد کنید:")
-    await state.set_state(SupportStates.ask_topic)
+    await state.set_state(SupportStates.waiting_for_subject)

--- a/vpn_bot/bot/handlers/support/support.py
+++ b/vpn_bot/bot/handlers/support/support.py
@@ -24,26 +24,26 @@ router = Router()
 @router.message(Command("support"))
 async def support_start(message: Message, state: FSMContext) -> None:
     """Entry point for support via command."""
-    await state.set_state(SupportStates.ask_topic)
+    await state.set_state(SupportStates.waiting_for_subject)
     await message.answer("لطفاً موضوع درخواست خود را وارد کنید.")
 
 
 @router.callback_query(F.data == "پشتیبانی")
 async def support_callback_handler(callback: CallbackQuery, state: FSMContext) -> None:
     """Entry point triggered from inline menu callback."""
-    await state.set_state(SupportStates.ask_topic)
+    await state.set_state(SupportStates.waiting_for_subject)
     await callback.message.answer("لطفاً موضوع درخواست خود را وارد کنید.")
 
 
-@router.message(SupportStates.ask_topic, F.text)
+@router.message(SupportStates.waiting_for_subject, F.text)
 async def support_receive_topic(message: Message, state: FSMContext) -> None:
     """Store topic and ask for description."""
     await state.update_data(topic=message.text)
-    await state.set_state(SupportStates.receive_description)
+    await state.set_state(SupportStates.waiting_for_description)
     await message.answer("لطفاً توضیح مشکل خود را اعلام کنید.")
 
 
-@router.message(SupportStates.receive_description, F.text)
+@router.message(SupportStates.waiting_for_description, F.text)
 async def support_receive_description(message: Message, state: FSMContext) -> None:
     """Forward the first message to admin and switch to live chat."""
     data = await state.get_data()

--- a/vpn_bot/bot/handlers/support/ticket_support.py
+++ b/vpn_bot/bot/handlers/support/ticket_support.py
@@ -21,17 +21,17 @@ logger = logging.getLogger(__name__)
 @router.message(Command("support"))
 async def support_start(message: Message, state: FSMContext):
     await message.answer("لطفاً موضوع تیکت را وارد کنید:", reply_markup=ReplyKeyboardRemove())
-    await state.set_state(SupportStates.ask_topic)
+    await state.set_state(SupportStates.waiting_for_subject)
 
 
-@router.message(SupportStates.ask_topic)
+@router.message(SupportStates.waiting_for_subject)
 async def get_subject(message: Message, state: FSMContext):
     await state.update_data(subject=message.text)
     await message.answer("لطفاً توضیحات خود را وارد کنید:")
-    await state.set_state(SupportStates.receive_description)
+    await state.set_state(SupportStates.waiting_for_description)
 
 
-@router.message(SupportStates.receive_description)
+@router.message(SupportStates.waiting_for_description)
 async def get_description(message: Message, state: FSMContext):
     data = await state.get_data()
     subject = data.get("subject", "")

--- a/vpn_bot/bot/states.py
+++ b/vpn_bot/bot/states.py
@@ -13,7 +13,7 @@ class SupportStates(StatesGroup):
     """States for user support ticket creation and live chat."""
 
     # فاز نخست پشتیبانی: دریافت موضوع و توضیح مشکل
-    ask_topic = State()
-    receive_description = State()
-    # پس از ثبت، کاربر وارد چت زنده می‌شود
+    waiting_for_subject = State()
+    waiting_for_description = State()
+    # پس از ثبت، کاربر وارد چت زنده می‌شود (در فازهای بعدی)
     live_chat = State()

--- a/vpn_bot/context/support.py
+++ b/vpn_bot/context/support.py
@@ -14,6 +14,6 @@ async_session = AsyncSessionLocal
 class SupportStates(StatesGroup):
     """FSM states for the basic support flow."""
 
-    ask_topic = State()
-    receive_description = State()
+    waiting_for_subject = State()
+    waiting_for_description = State()
     live_chat = State()


### PR DESCRIPTION
## Summary
- rename support FSM states to `waiting_for_subject` and `waiting_for_description`
- update handlers to use new state names
- keep live chat support intact

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_6844658809c4832197aa492d7627e6fa