### PR TITLE
Implement startup admin notification and update support handlers

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from vpn_bot.services.payment.scheduler import start_scheduler
 from config import LOG_LEVEL, ENVIRONMENT
 from vpn_bot.bot_instance import bot, dp
 from vpn_bot.bot.core import register_handlers
+from vpn_bot.bot.startup import register as register_startup
 # =======================
 # 🚀 راه‌اندازی ربات
 # =======================
@@ -44,6 +45,7 @@ async def main():
     dp.callback_query.middleware(AntiBreakMiddleware())
     # — ثبت هندلرها و
     register_handlers(dp)
+    register_startup(dp)
       # — اجرای Scheduler در پس‌زمینه
     asyncio.create_task(start_scheduler())
 

--- a/scripts/tests/test_startup.py
+++ b/scripts/tests/test_startup.py
@@ -1,0 +1,10 @@
+import pytest
+from unittest.mock import AsyncMock
+from vpn_bot.bot.startup import notify_admins
+
+@pytest.mark.asyncio
+async def test_notify_admins(monkeypatch):
+    bot = AsyncMock()
+    monkeypatch.setattr("vpn_bot.bot.startup.ADMIN_IDS", [123])
+    await notify_admins(bot)
+    bot.send_message.assert_awaited_with(chat_id=123, text="✅ تست اتصال به ادمین موفق بود.")

--- a/vpn_bot/bot/handlers/support/ticket_support.py
+++ b/vpn_bot/bot/handlers/support/ticket_support.py
@@ -19,20 +19,21 @@ router = Router()
 logger = logging.getLogger(__name__)
 
 @router.message(Command("support"))
-async def support_start(message: Message, state: FSMContext):
+@router.message(lambda m: m.text == "پشتیبانی")
+async def enter_support(message: Message, state: FSMContext):
     await message.answer("لطفاً موضوع تیکت را وارد کنید:", reply_markup=ReplyKeyboardRemove())
     await state.set_state(SupportStates.waiting_for_subject)
 
 
 @router.message(SupportStates.waiting_for_subject)
-async def get_subject(message: Message, state: FSMContext):
+async def got_subject(message: Message, state: FSMContext):
     await state.update_data(subject=message.text)
     await message.answer("لطفاً توضیحات خود را وارد کنید:")
     await state.set_state(SupportStates.waiting_for_description)
 
 
 @router.message(SupportStates.waiting_for_description)
-async def get_description(message: Message, state: FSMContext):
+async def got_description(message: Message, state: FSMContext):
     data = await state.get_data()
     subject = data.get("subject", "")
     description = message.text
@@ -58,7 +59,7 @@ async def get_description(message: Message, state: FSMContext):
 
 
 @router.message(lambda m: m.from_user.id in OPERATORS)
-async def operator_reply(message: Message):
+async def operator_message(message: Message):
     operator_id = message.from_user.id
     ticket_id = await get_active_ticket_for_operator(operator_id)
     if not ticket_id:

--- a/vpn_bot/bot/startup.py
+++ b/vpn_bot/bot/startup.py
@@ -1,0 +1,17 @@
+import logging
+from aiogram import Bot, Dispatcher
+from config import ADMIN_IDS
+
+logger = logging.getLogger(__name__)
+
+async def notify_admins(bot: Bot) -> None:
+    for admin_id in ADMIN_IDS:
+        try:
+            await bot.send_message(chat_id=admin_id, text="✅ تست اتصال به ادمین موفق بود.")
+        except Exception as e:
+            logger.error(f"خطا در ارسال پیام تست به {admin_id}: {e}")
+            raise
+
+
+def register(dp: Dispatcher) -> None:
+    dp.startup.register(notify_admins)


### PR DESCRIPTION
## Summary
- notify admins on bot startup via new `notify_admins` handler
- register startup handler in `main.py`
- expand ticket support flow triggered by “پشتیبانی” text and rename handlers
- add unit test for startup notification

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68449b22f45c8321ac9d3c5cd5ad4d41