### PR TITLE
Handle optional openai dependency

### DIFF
--- a/vpn_bot/ai_support/ai.py
+++ b/vpn_bot/ai_support/ai.py
@@ -1,11 +1,19 @@
-"""GPT-4 Turbo client and response helper."""
+"""GPT-4 Turbo client and response helper.
+
+If the optional ``openai`` dependency is missing, all completion calls will
+gracefully return an empty string instead of raising errors.
+"""
 
 import logging
 from functools import lru_cache
 
-import openai
-
 logger = logging.getLogger("ai-support")
+
+try:  # pragma: no cover - optional dependency
+    import openai  # type: ignore
+except ImportError:  # pragma: no cover - openai not installed
+    logger.warning("OpenAI package not available; AI features disabled.")
+    openai = None  # type: ignore
 
 FA_TEMPLATE = "کاربر پرسید: {question}\nپاسخ کوتاه:"  # فارسی
 EN_TEMPLATE = "User asked: {question}\nShort answer:"
@@ -14,10 +22,17 @@ THRESHOLD = 0.7
 
 @lru_cache(maxsize=128)
 def _cached_completion(prompt: str) -> str:
+    """Return a cached completion or an empty string if OpenAI is unavailable."""
+    if openai is None:  # library missing
+        logger.warning("OpenAI module not installed; returning empty completion.")
+        return ""
+
     try:
-        resp = openai.ChatCompletion.create(model="gpt-4-turbo", messages=[{"role": "user", "content": prompt}])
+        resp = openai.ChatCompletion.create(
+            model="gpt-4-turbo", messages=[{"role": "user", "content": prompt}]
+        )
         return resp.choices[0].message.content
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - network failures
         logger.exception("OpenAI request failed: %s", e)
         return ""
 


### PR DESCRIPTION
## Summary
- warn if openai isn't installed and disable AI features gracefully
- fail safely in `_cached_completion` when openai is unavailable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for aiogram, httpx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68449f758574832180aac9927f510cd3